### PR TITLE
Fixed non-display of Cache Devices tab

### DIFF
--- a/plugins/dynamix/CacheDevices.page
+++ b/plugins/dynamix/CacheDevices.page
@@ -1,6 +1,6 @@
 Menu="Main:2"
 Title="Cache Devices"
-Cond="($var['fsState']=='Stopped' || (is_dir('/mnt/cache') && is_dir('/mnt/user0')))"
+Cond="($var['fsState']=='Stopped' || is_dir('/mnt/cache'))"
 ---
 <?PHP
 /* Copyright 2014, Lime Technology

--- a/plugins/dynamix/DiskHealth.page
+++ b/plugins/dynamix/DiskHealth.page
@@ -15,10 +15,20 @@ Title="Health"
 ?>
 <?
 $disk  = $disks[$name];
-$cname = my_disk($disk['name']);
+$cname = my_disk($name);
 $dev   = $disk['device'];
-$file  = "/var/tmp/{$disk['name']}-attributes";
+$file  = "/var/tmp/$name-attributes";
 exec("smartctl -A /dev/$dev >$file");
+$refs = array(); $n = 0;
+foreach ($disks as $ref) {
+  if ($ref['name']=='flash') continue;
+  $refs[] = $ref['name'];
+  if ($ref['name']==$name) $i = $n;
+  $n++;
+}
+$end = count($refs)-1;
+$prev = $i>0 ? $refs[$i-1] : $refs[$end];
+$next = $i<$end ? $refs[$i+1] : $refs[0];
 ?>
 <link type="text/css" rel="stylesheet" href="/webGui/styles/disk.health.css">
 <link type="text/css" rel="stylesheet" href="/webGui/styles/jquery.stylesidebar.css">
@@ -45,4 +55,4 @@ $(function(){$('li').StyleSidebar({displayDivId:'mainContent',pageMinHeight:'aut
 </ul>
 <div id="mainContent"><!-- content  --></div>
 </div>
-<button type="button" onclick="saveSMART()">Attributes</button><button type="button" onclick="done()">Done</button>
+<a href='/Main/Data?name=<?=$prev?>'><input type='button' value='Previous'></a><a href='/Main/Data?name=<?=$next?>'><input type='button' value='Next'></a><button type="button" onclick="saveSMART()">Attributes</button><button type="button" onclick="done()">Done</button>

--- a/plugins/dynamix/ParityCheck.page
+++ b/plugins/dynamix/ParityCheck.page
@@ -69,11 +69,6 @@ $(function() {
   $('form[name="parity_settings"]').find('input[value="Apply"]').removeAttr('disabled');
 <?unlink($memory);?>
 <?endif;?>
-  showStatus('crontab','dynamix','parity-check');
-<?if (!$display['tabs']):?>
-  $('input[id^=tab]').bind({click:function(){$('#progress').hide();}});
-  $('#tab1').bind({click:function(){$('#progress').show();}});
-<?endif;?>
   presetParity(document.parity_settings);
 });
 function presetParity(form) {

--- a/plugins/dynamix/include/DashUpdate.php
+++ b/plugins/dynamix/include/DashUpdate.php
@@ -22,7 +22,7 @@ function my_smart(&$source,$name) {
   $last = isset($saved["smart"]["$name.5"]) ? $saved["smart"]["$name.5"] : 0;
   $smart = exec("awk '$1==5 {print $10}' /var/local/emhttp/smart/$name");
   $thumb = $smart>$last ? 'bad' : 'good';
-  my_insert($source, "<a href=\"Main/Data?name=$name\" onclick=\"$.cookie('one','tab2',{path:'/'})\" title=\"$smart reallocated sectors\"><img src=\"$path/$thumb.png\"></a>");
+  my_insert($source, "<a href=\"/Main/Data?name=$name\" onclick=\"$.cookie('one','tab2',{path:'/'})\" title=\"$smart reallocated sectors\"><img src=\"$path/$thumb.png\"></a>");
 }
 function my_usage(&$source,$used) {
   my_insert($source, $used ? "<div class='usage-disk all'><span style='width:$used'>$used</span></div>" : "-");

--- a/plugins/dynamix/include/DashUpdate.php
+++ b/plugins/dynamix/include/DashUpdate.php
@@ -22,7 +22,7 @@ function my_smart(&$source,$name) {
   $last = isset($saved["smart"]["$name.5"]) ? $saved["smart"]["$name.5"] : 0;
   $smart = exec("awk '$1==5 {print $10}' /var/local/emhttp/smart/$name");
   $thumb = $smart>$last ? 'bad' : 'good';
-  my_insert($source, "<a href=\"Data?name=$name\" onclick=\"$.cookie('one','tab2',{path:'/'})\" title=\"$smart reallocated sectors\"><img src=\"$path/$thumb.png\"></a>");
+  my_insert($source, "<a href=\"Main/Data?name=$name\" onclick=\"$.cookie('one','tab2',{path:'/'})\" title=\"$smart reallocated sectors\"><img src=\"$path/$thumb.png\"></a>");
 }
 function my_usage(&$source,$used) {
   my_insert($source, $used ? "<div class='usage-disk all'><span style='width:$used'>$used</span></div>" : "-");


### PR DESCRIPTION
This fixes the issue when people have set the global settings of cache to "no", but still use the cache drive. In that case it has be visible on the main page.