### PR TITLE
Table header correction for markdown conversion

### DIFF
--- a/plugins/dynamix.docker.manager/DockerRepositories.page
+++ b/plugins/dynamix.docker.manager/DockerRepositories.page
@@ -14,7 +14,6 @@ $template_repos = $dockerManPaths['template-repos'];
 ?>
 <form markdown="1" method="POST" action="/plugins/dynamix.docker.manager/update_cfg.php" target="progressFrame">
 <input type="hidden" name="#action" value="templates" />
-
 Template repositories:
 : <textarea name="template_repos" rows="5" cols="100" style="width:550px"><?=@file_get_contents($template_repos);?></textarea>
 

--- a/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/plugins/dynamix.docker.manager/DockerSettings.page
@@ -54,7 +54,6 @@ if (file_exists($realfile)) {
 <form id="settingsForm" markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#file" value="<?=$cfgfile;?>" />
 <input type="hidden" id="command" name="#command" value="/etc/rc.d/rc.docker stop" />
-
 Enable Docker:
 : <select id="DOCKER_ENABLED" name="DOCKER_ENABLED" size="1">
 <?= mk_option($dockercfg['DOCKER_ENABLED'], 'no', 'No'); ?>

--- a/plugins/dynamix.plugin.manager/Plugins.page
+++ b/plugins/dynamix.plugin.manager/Plugins.page
@@ -15,12 +15,12 @@ Tabs="true"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 // Remove stale /tmp/plugin/*.plg entries
 $tmp_stale = ($path != $prev);
 if ($tmp_stale) foreach (glob("/tmp/plugins/*.{plg,txt}", GLOB_NOSORT+GLOB_BRACE) as $entry) if (!file_exists("/var/log/plugins/".basename($entry))) @unlink($entry);
 ?>
-
 <link type="text/css" rel="stylesheet" href="/webGui/styles/jqueryFileTree.css">
 <style type="text/css">
   #plugin_tree{width:33%;height:200px;overflow:scroll;}
@@ -43,7 +43,7 @@ $(function() {
 Click <strong><big>check for updates</big></strong> to check all plugins. This page might take some time to load depending on your internet connection and how many plugins need to be checked.
 </blockquote>
 
-<table class='tablesorter plugins <?=$display['tabs']==1?"shift":""?>' id='plugin_table'>
+<table class='tablesorter plugins' id='plugin_table'>
 <thead><tr><th></th><th>Plugin</th><th>Author</th><th>Version</th><th>Status</th><th></th></tr></thead>
 <tbody id='plugin_list'><tr><td colspan='6'><br><i>Please wait, retrieving plugin information ...</i></td><tr></tbody>
 </table>

--- a/plugins/dynamix.plugin.manager/PluginsError.page
+++ b/plugins/dynamix.plugin.manager/PluginsError.page
@@ -14,7 +14,8 @@ Cond="glob('/boot/config/plugins-error/*.plg')"
  * all copies or substantial portions of the Software.
  */
 ?>
-<?PHP
+
+<?
 echo "<table class='tablesorter' id='plugin_table'><thead>";
 echo "<tr><th>Plugin File</th><th>Status</th></tr>";
 echo "</thead><tbody>";

--- a/plugins/dynamix.plugin.manager/PluginsStale.page
+++ b/plugins/dynamix.plugin.manager/PluginsStale.page
@@ -14,6 +14,7 @@ Cond="glob('/boot/config/plugins-stale/*.plg')"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 echo "<table class='tablesorter plugins shift' id='plugin_table'><thead>";
 echo "<tr><th></th><th>Plugin</th><th>Author</th><th>Version</th><th>Status</th><th></th></tr>";

--- a/plugins/dynamix.xen.manager/Domain.page
+++ b/plugins/dynamix.xen.manager/Domain.page
@@ -12,6 +12,7 @@ Title="Domain '$name' Settings"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 function domid($domname) {
   $domid = exec("xl domid $domname 2>&1", $output, $retval);
@@ -81,7 +82,6 @@ Domain path:
 <? if ($domid): ?>
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#command" value="/usr/local/sbin/xenman shutdown <?=$domname;?>" />
-
 Status:
 : Started
 
@@ -94,7 +94,6 @@ Status:
 <? else: ?>
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#command" value="/usr/local/sbin/xenman start <?=$domname;?>" />
-
 Status:
 : Shut down
 
@@ -107,7 +106,6 @@ Status:
 
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#command" value="/usr/local/sbin/xenman delete <?=$domname;?>" />
-
 &nbsp;
 : <input type="submit" value="Delete" />
 
@@ -120,7 +118,6 @@ Status:
 
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#file" value="<?=$domcfgfile;?>" />
-
 Domain config file:
 : <?=$domcfgfile;?>
 
@@ -149,7 +146,6 @@ function set_default_configfile_text(form) {
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#include" value="update.file.php" />
 <input type="hidden" name="#file" value="<?=$configfile;?>" />
-
 Xen config file:
 : <?=$configfile;?>
 
@@ -180,7 +176,6 @@ function set_default_readmefile_text(form) {
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#include" value="update.file.php" />
 <input type="hidden" name="#file" value="<?=$readmefile;?>" />
-
 README.md:
 : <?=$readmefile;?>
 

--- a/plugins/dynamix.xen.manager/Domains.page
+++ b/plugins/dynamix.xen.manager/Domains.page
@@ -24,8 +24,7 @@ $(function() {
   $('#plugin_tree').fileTree({root:'/boot/'}, function(file) {$('#domain_file').val(file);});
 });
 </script>
-
-<?PHP
+<?
 function domid($domname) {
   $domid = exec("xl domid $domname 2>&1", $output, $retval);
   if ($retval != 0) $domid = false;
@@ -38,7 +37,7 @@ function dominfo($domid) {
 function parse_configfile($configfile) {
   return json_decode(shell_exec("xl -N create $configfile | tail -n +2"), true);
 }
-echo "<table class='tablesorter xenman".($display['tabs']==1?" shift'":"'")." id='domain_table'><thead>";
+echo "<table class='tablesorter xenman' id='domain_table'><thead>";
 echo "<tr><th></th><th>Name</th><th>ID</th><th>Mem(MB)</th><th>VCPUs</th><th>State</th><th>Time(s)</th><th>Autostart</th></tr>";
 echo "</thead><tbody>";
 

--- a/plugins/dynamix.xen.manager/Xen.page
+++ b/plugins/dynamix.xen.manager/Xen.page
@@ -14,7 +14,8 @@ Tabs="true"
  * all copies or substantial portions of the Software.
  */
 ?>
-<?PHP
+
+<?
 // array must be started since that's where we store the domains
 
 if ($var['fsState'] != "Started") {

--- a/plugins/dynamix/ArrayOperation.page
+++ b/plugins/dynamix/ArrayOperation.page
@@ -13,6 +13,7 @@ Title="Array Operation"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 function maintenance_mode() {
   echo "<tr>";

--- a/plugins/dynamix/Browse.page
+++ b/plugins/dynamix/Browse.page
@@ -12,6 +12,7 @@ Title="Index of $dir"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 /* Create list of objects in directory given by global $dir variable.  The list
  * is sorted by $field (type, name, size, time or disk), either SORT_ASC or SORT_DESC

--- a/plugins/dynamix/CacheSettings.page
+++ b/plugins/dynamix/CacheSettings.page
@@ -14,6 +14,7 @@ Cond="((isset($disks['cache']))&&($disks['cache']['status']!='DISK_NP'))"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?$disabled = $var['fsState']!="Stopped" ? 'disabled' : ''?>
 
 <script>

--- a/plugins/dynamix/Confirmations.page
+++ b/plugins/dynamix/Confirmations.page
@@ -31,7 +31,6 @@ function resetConfirm(form) {
 <form markdown="1" name="confirm_settings" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#file" value="dynamix/dynamix.cfg"/>
 <input type="hidden" name="#section" value="confirm"/>
-
 Confirm reboot & powerdown commands:
 : <select name="down" size="1">
   <?=mk_option($confirm['down'], "0", "No")?>

--- a/plugins/dynamix/DashStats.page
+++ b/plugins/dynamix/DashStats.page
@@ -13,6 +13,7 @@ Title="Statistics"
  * all copies or substantial portions of the Software.
 */
 ?>
+
 <?
 $cores = exec('nproc');
 $fans  = exec("sensors -uA|grep -c 'fan[0-9]_input'");

--- a/plugins/dynamix/DeviceInfo.page
+++ b/plugins/dynamix/DeviceInfo.page
@@ -14,6 +14,7 @@ Cond="($disks[$name]['status']!='DISK_NP')&&($disks[$name]['status']!='DISK_NP_O
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?$disk = $disks[$name]?>
 
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">

--- a/plugins/dynamix/DiskHealth.page
+++ b/plugins/dynamix/DiskHealth.page
@@ -13,6 +13,7 @@ Title="Health"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $disk  = $disks[$name];
 $cname = my_disk($name);

--- a/plugins/dynamix/DisplaySettings.page
+++ b/plugins/dynamix/DisplaySettings.page
@@ -92,7 +92,6 @@ function resetDisplay(form) {
 <form markdown="1" name="display_settings" method="POST" action="/update.php" target="progressFrame" onsubmit="return prepareDisplay(this)">
 <input type="hidden" name="#file" value="dynamix/dynamix.cfg"/>
 <input type="hidden" name="#section" value="display"/>
-
 Date format:
 : <select name="date" size="1" onchange="presetTime(this.form)">
   <?=mk_option($display['date'], "%c", "System Setting")?>

--- a/plugins/dynamix/FTP.page
+++ b/plugins/dynamix/FTP.page
@@ -14,6 +14,7 @@ Icon="ftp-server.png"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $ftp_userlist_file = "/boot/config/vsftpd.user_list";
 $ftp_userlist = "";
@@ -31,7 +32,6 @@ $(function() {
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="cmd" value="echo">
 <input type="hidden" name="arg2" value="| tr ' ' '\n' > <?=$ftp_userlist_file;?>">
-
 FTP user(s):
 : <input type="text" name="arg1" size="40" maxlength="80" value="<?=$ftp_userlist;?>">
 

--- a/plugins/dynamix/MoverSettings.page
+++ b/plugins/dynamix/MoverSettings.page
@@ -14,6 +14,7 @@ Cond="(($var['shareUser']!='-')&&(isset($disks['cache']))&&($disks['cache']['sta
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $cron = explode(' ',$var['shareMoverSchedule']);
 $move = $cron[2]!='*' ? 3 : ($cron[4]!='*' ? 2 : (substr($cron[1],0,1)!='*' ? 1 : 0));

--- a/plugins/dynamix/NewPerms.page
+++ b/plugins/dynamix/NewPerms.page
@@ -33,15 +33,6 @@ For readonly files:
 Clicking Start will open another window and start the background process. Closing the window before
 completion will terminate the background process - so don't do that. This process can take a long time if you have many files.
 
-<?PHP
-/* Copyright 2014, Lime Technology LLC.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2, or (at your option)
- * any later version.
- */
-/* Program updates made by Bergware International (October 2014) */
-?>
 <?$cmd = '/usr/local/sbin/newperms';?>
 
 <form method="POST" action="/update.htm" target="progressFrame">

--- a/plugins/dynamix/Notifications.page
+++ b/plugins/dynamix/Notifications.page
@@ -16,6 +16,7 @@ Icon="notifications.png"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $events = explode('|', $notify['events']);
 $disabled = $notify['system'] ? '' : 'disabled';
@@ -103,7 +104,6 @@ $(function(){
 <input type="hidden" name="docker_notify">
 <input type="hidden" name="report">
 <input type="hidden" name="events">
-
 Date format:
 : <select name="date" size="1">
   <?=mk_option($notify['date'], "d-m-Y", "DD-MM-YYYY")?>

--- a/plugins/dynamix/NotificationsArchive.page
+++ b/plugins/dynamix/NotificationsArchive.page
@@ -14,6 +14,7 @@ Title="Archived Notifications"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $path = "{$notify['path']}/archive/*.notify";
 $files = count(glob($path, GLOB_NOSORT));
@@ -34,7 +35,7 @@ function askConfirmation() {
 $(archiveList);
 </script>
 
-<table class="tablesorter shift<?=$tabbed?'2':''?>" id="archive_table">
+<table class="tablesorter shift" id="archive_table">
 <thead><tr><th>Time</th><th>Event</th><th>Subject</th><th>Description</th><th style='width:7%'>Importance</th><th style='width:5%;text-align:center'>Delete<?if ($files>1):?> <a href='/webGui/include/DeleteLogFile.php?log=<?=$path?>' target='progressFrame' onclick='return askConfirmation()' title='Delete all notifications'>[x]</a><?endif;?></th></tr></thead>
 <tbody id="archive_list"></tbody>
 </table>

--- a/plugins/dynamix/OpenDevices.page
+++ b/plugins/dynamix/OpenDevices.page
@@ -14,6 +14,7 @@ Cond="((count($devs)>0)&&($var['fsState']=='Started'))"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $tabX = '#tab'.($var['fsState']=='Stopped'||is_dir('/mnt/cache') ? '4' : '3');
 ?>

--- a/plugins/dynamix/PageMap.page
+++ b/plugins/dynamix/PageMap.page
@@ -13,6 +13,7 @@ Title="Page Map"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 function show_map($menu, $level) {
   $pages = find_pages( $menu);

--- a/plugins/dynamix/ParityCheck.page
+++ b/plugins/dynamix/ParityCheck.page
@@ -14,6 +14,7 @@ Cond="($disks['parity']['status']!='DISK_DSBL_NP')"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $mode = array('Disabled','Daily','Weekly','Monthly','Yearly','Every');
 $days = array('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday');
@@ -89,7 +90,6 @@ function resetParity(form) {
 <input type="hidden" name="#file" value="dynamix/dynamix.cfg"/>
 <input type="hidden" name="#section" value="parity"/>
 <input type="hidden" name="#include" value="update.parity.php"/>
-
 Scheduled parity check:
 : <select name="mode" size="1" onchange="submit()">
   <?for ($m=0; $m<count($mode); $m++):?>

--- a/plugins/dynamix/Processes.page
+++ b/plugins/dynamix/Processes.page
@@ -13,7 +13,8 @@ Title="Processes"
  * all copies or substantial portions of the Software.
  */
 ?>
-<?PHP
+
+<?
 echo "<pre class='up'>".shell_exec('ps -ef')."</pre>";
 ?>
 <button type="button" onclick="done()">Done</button>

--- a/plugins/dynamix/SecurityAFP.page
+++ b/plugins/dynamix/SecurityAFP.page
@@ -99,12 +99,8 @@ Security:
 <?if ($sec_afp[$name]['security'] == 'secure'):?>
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name;?>">
-
-&nbsp;
-
-User Access:
-: Guests have **read-only** access.
-  <?input_secure_users($sec_afp);?>
+<div id="title"><dt>User Access</dt><em>Guests have <b>read-only</b> access.</em></div>
+<?input_secure_users($sec_afp);?>
 
 &nbsp;
 : <input type='submit' name='changeShareAccessAFP' value='Apply'><button type='button' onclick='done()'>Done</button>
@@ -113,12 +109,8 @@ User Access:
 <?elseif ($sec_afp[$name]['security'] == 'private'):?>
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name;?>">
-
-&nbsp;
-
-User Access:
-: Guests have **no access**.
-  <?input_private_users($sec_afp);?>
+<div id="title"><dt>User Access</dt><em>Guests have <b>no</b> access.</em></div>
+<?input_private_users($sec_afp);?>
 
 &nbsp;
 : <input type='submit' name='changeShareAccessAFP' value='Apply'><button type='button' onclick='done()'>Done</button>

--- a/plugins/dynamix/SecurityAFP.page
+++ b/plugins/dynamix/SecurityAFP.page
@@ -27,7 +27,6 @@ $(checkShareSettingsAFP);
 
 <form markdown="1" name="afp_security_form" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name;?>">
-
 Name:
 : <?=preg_match('/^(disk[0-9]|cache[0-9]?)/',$name) ? my_disk($name) : $name?>
 

--- a/plugins/dynamix/SecurityNFS.page
+++ b/plugins/dynamix/SecurityNFS.page
@@ -16,7 +16,6 @@ Cond="(($var['shareNFSEnabled']=='yes') && (isset($name)?array_key_exists($name,
 ?>
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name;?>">
-
 Name:
 : <?=preg_match('/^(disk[0-9]|cache[0-9]?)/',$name) ? my_disk($name) : $name?>
 

--- a/plugins/dynamix/SecurityNFS.page
+++ b/plugins/dynamix/SecurityNFS.page
@@ -39,7 +39,6 @@ Security:
 <?if ($sec_nfs[$name]['security']=="private"):?>
 <form markdown="1" method="POST" name="otherForm" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name;?>">
-
 Rule:
 : <input type="text" name="shareHostListNFS" maxlength="256" value="<?=$sec_nfs[$name]['hostList'];?>">
 

--- a/plugins/dynamix/SecuritySMB.page
+++ b/plugins/dynamix/SecuritySMB.page
@@ -53,12 +53,8 @@ Security:
 <?if ($sec[$name]['security'] == 'secure'):?>
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name?>">
-
-&nbsp;
-
-User Access:
-: Guests have **read-only** access.
-  <?input_secure_users($sec);?>
+<div id="title"><dt>User Access</dt><em>Guests have <b>read-only</b> access.</em></div>
+<?input_secure_users($sec);?>
 
 &nbsp;
 : <input type='submit' name='changeShareAccess' value='Apply'><button type='button' onclick='done()'>Done</button>
@@ -67,12 +63,8 @@ User Access:
 <?elseif ($sec[$name]['security'] == 'private'):?>
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name?>">
-
-&nbsp;
-
-User Access:
-: Guests have **no** access.
-  <?input_private_users($sec);?>
+<div id="title"><dt>User Access</dt><em>Guests have <b>no</b> access.</em></div>
+<?input_private_users($sec);?>
 
 &nbsp;
 : <input type='submit' name='changeShareAccess' value='Apply'><button type='button' onclick='done()'>Done</button>

--- a/plugins/dynamix/SecuritySMB.page
+++ b/plugins/dynamix/SecuritySMB.page
@@ -16,7 +16,6 @@ Cond="(($var['shareSMBEnabled']=='yes') && (isset($name)?array_key_exists($name,
 ?>
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="shareName" value="<?=$name?>">
-
 Name:
 : <?=preg_match('/^(disk[0-9]|cache[0-9]?|flash)/',$name) ? my_disk($name) : $name?>
 

--- a/plugins/dynamix/ShareEdit.page
+++ b/plugins/dynamix/ShareEdit.page
@@ -13,6 +13,7 @@ Title="Share Settings"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 if ($name == "") {
   /* default values when adding new share */
@@ -127,7 +128,6 @@ function prepareEdit(form) {
 
 <form markdown="1" name="share_edit" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareEdit(this)">
 <input type="hidden" name="shareNameOrig" value="<?=$share['nameOrig']?>">
-
 Name:
 : <input type="text" name="shareName" maxlength="40" value="<?=$share['name']?>">
 

--- a/plugins/dynamix/ShareList.page
+++ b/plugins/dynamix/ShareList.page
@@ -13,6 +13,7 @@ Title="User Shares"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 // User share data exists only if array is Started
 if ($var['fsState']!="Started") {

--- a/plugins/dynamix/SmtpSettings.page
+++ b/plugins/dynamix/SmtpSettings.page
@@ -13,6 +13,7 @@ Title="SMTP Settings"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 $incomplete = strlen($ssmtp['root'])==0 || strlen($ssmtp['server'])==0 || strlen($ssmtp['port'])==0 || ((strlen($ssmtp['AuthUser'])==0 || strlen($ssmtp['AuthPass'])==0) && $ssmtp['AuthMethod']!='none');
 ?>
@@ -71,7 +72,6 @@ function settings(form, data) {
 <input type="hidden" name="#file"  value="dynamix/dynamix.cfg">
 <input type="hidden" name="#section" value="ssmtp">
 <input type="hidden" name="#command" value="/usr/local/sbin/notify smtp-init">
-
 Preset service:
 : <select name="service" size="1" onchange="settings(this.form,this.value)">
 <?=mk_option($ssmtp['service'], "smtp.gmail.com:465:YES:NO:login", "Gmail")?>

--- a/plugins/dynamix/Syslinux.page
+++ b/plugins/dynamix/Syslinux.page
@@ -16,7 +16,7 @@ Title="Syslinux Configuration"
 > Use this page to make changes to your `syslinux.cfg` file.  You will
 > need to reboot your server for these changes to take effect.
 
-<?PHP
+<?
 $file = "/boot/syslinux/syslinux.cfg";
 $text = file_get_contents($file);
 $default_text = @file_get_contents("$file-");
@@ -30,7 +30,6 @@ function setDefault(form) {
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#include" value="update.file.php">
 <input type="hidden" name="#file" value="<?=$file;?>">
-
 Syslinux configuration:
 
 : <textarea spellcheck="false" cols="80" rows="22" maxlength="2048" name="text" style="font-family:bitstream;width:66%"><?=$text;?></textarea>

--- a/plugins/dynamix/Syslog.page
+++ b/plugins/dynamix/Syslog.page
@@ -13,7 +13,8 @@ Title="System Log"
  * all copies or substantial portions of the Software.
  */
 ?>
-<?PHP
+
+<?
 echo "<pre class='up'>".shell_exec('cat /var/log/syslog')."</pre>";
 ?>
 <script>

--- a/plugins/dynamix/UserEdit.page
+++ b/plugins/dynamix/UserEdit.page
@@ -13,6 +13,7 @@ Title="Edit User"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?if (!array_key_exists($name, $users)):?>
   <p class="notice">User <?=$name?> has been deleted.</p><br>
   <button type="button" onClick="done()">OK</button>
@@ -23,7 +24,6 @@ Title="Edit User"
 
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="userName" value="<?=$user['name'];?>">
-
 User name:
 : <?=$user['name']?>
 
@@ -42,7 +42,6 @@ Delete<input type="checkbox" name="confirmDelete" onChange="chkDelete(this.form,
 
 <form markdown="1" method="POST" action="/update.htm" target="progressFrame">
 <input type="hidden" name="userName" value="<?=$user['name'];?>">
-
 Password:
 : <input type="password" name="userPassword" maxlength="40" onKeyUp="this.form.cmdUserEdit.disabled = (this.form.userPassword.value != this.form.userPasswordConf.value);">
 

--- a/plugins/dynamix/UserList.page
+++ b/plugins/dynamix/UserList.page
@@ -13,6 +13,7 @@ Title="Users"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?foreach ($users as $user):?>
   <div class="user-list"><center><a href="<?=$path?>/UserEdit?name=<?=$user['name'];?>"><img src="/webGui/images/user.png" border="0"><br><?=$user['name']?></a><br><span style="font-size: 10px"><?=$user['desc']?></span></center></div>
 <?endforeach;?>

--- a/plugins/dynamix/Vars.page
+++ b/plugins/dynamix/Vars.page
@@ -13,6 +13,7 @@ Title="Vars"
  * all copies or substantial portions of the Software.
  */
 ?>
+
 <?
 foreach ($site as &$page) $page['text'] = '...';
 $myPage['text'] = '...';

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -183,7 +183,7 @@ $(function() {
   Shadowbox.setup('a.sb-enable', {modal:true});
 <?if ($confirm['warn']):?>
   $('input[value="Apply"]').attr('disabled','disabled');
-  $('form').find('select,input[type=text],input[type=password],input[type=checkbox]').each(function(){$(this).change(function(){$(this).parentsUntil('form').parent().find('input[value="Apply"]').removeAttr('disabled');});});
+  $('form').find('select,input[type=text],input[type=password],input[type=checkbox],textarea').each(function(){$(this).change(function(){$(this).parentsUntil('form').parent().find('input[value="Apply"]').removeAttr('disabled');});});
 <?endif;?>
   timers.watchdog = setTimeout(watchdog,50);
 });

--- a/plugins/dynamix/include/Helpers.php
+++ b/plugins/dynamix/include/Helpers.php
@@ -148,7 +148,7 @@ function pgrep($process_name) {
 }
 function input_secure_users($sec) {
   global $name, $users;
-  echo "<table class='settings shifted'>";
+  echo "<table class='settings'>";
   $write_list = explode(",", $sec[$name]['writeList']);
   foreach ($users as $user) {
     $idx = $user['idx'];
@@ -170,7 +170,7 @@ function input_secure_users($sec) {
 }
 function input_private_users($sec) {
   global $name, $users;
-  echo "<table class='settings shifted'>";
+  echo "<table class='settings'>";
   $read_list = explode(",", $sec[$name]['readList']);
   $write_list = explode(",", $sec[$name]['writeList']);
   foreach ($users as $user) {

--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -14,7 +14,7 @@ a.info:hover span.left{left:-182px;}
 a.nohand{cursor:default;}
 i.spacing{margin-left:-6px;margin-right:-4px;}
 hr{border:none;margin:12px 0;}
-input[type=text],input[type=password],input[type=number],input[type=url],input[type=email],textarea,.textarea{font-family:arimo;font-size:11px;color:#808080;background-color:#000000;border:1px solid #404040;padding:2px 6px;min-height:20px;line-height:20px;outline:none;width:305px;margin:0 10px 0 0;box-shadow:inset 1px 1px 5px #404040;}
+input[type=text],input[type=password],input[type=number],input[type=url],input[type=email],textarea,.textarea{font-family:arimo;font-size:11px;color:#808080;background-color:#000000;border:1px solid #404040;border-radius:4px;padding:2px 6px;min-height:20px;line-height:20px;outline:none;width:305px;margin:0 10px 0 0;box-shadow:inset 1px 1px 5px #404040;}
 input[type=submit],input[type=reset],input[type=button],button[type=button],a.button{font-family:arimo;font-size:11px;position:relative;display:inline-block;padding:5px 10px;border:1px solid #303030;border-radius:5px;margin:7px 14px 0 0;text-decoration:none;white-space:nowrap;cursor:pointer;outline:none;color:#808080;background:-webkit-radial-gradient(#505050,#181818);background:linear-gradient(#505050,#181818);}
 input[type=checkbox]{vertical-align:middle;margin-right:6px;}
 input[type=number]::-webkit-outer-spin-button,input[type=number]::-webkit-inner-spin-button{-webkit-appearance: none;}

--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -194,7 +194,7 @@ div.up{margin-top:-20px;}
 pre.up{margin-top:-20px;}
 pre{border:1px solid #202020;font-family:bitstream;font-size:11px;padding:6px 12px;overflow:auto;}
 iframe#progressFrame{position:fixed;bottom:32px;left:0;margin:0;padding:8px 8px 0 8px;width:100%;height:12px;line-height:12px;border-style:none;overflow:hidden;font-family:bitstream;font-size:10px;color:#A0A0A0;white-space:nowrap;z-index:-10;}
-dl{margin:0;padding-left:12px;}
+dl{margin:0;padding-left:12px;line-height:22px;}
 dt{clear:left;float:left;width:33%;font-weight:bold;}
 dd{margin-bottom:12px;font-size:11px;white-space:nowrap;}
 dd p{margin:0 0 4px 0;}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -193,7 +193,7 @@ div.up{margin-top:-20px;}
 pre.up{margin-top:-20px;}
 pre{border:1px solid #D0D0D0;font-family:bitstream;font-size:11px;padding:6px 12px;overflow:auto;}
 iframe#progressFrame{position:fixed;bottom:32px;left:0;margin:0;padding:8px 8px 0 8px;width:100%;height:12px;line-height:12px;border-style:none;overflow:hidden;font-family:bitstream;font-size:10px;color:#505050;white-space:nowrap;z-index:-10;}
-dl{margin:0;padding-left:12px;}
+dl{margin:0;padding-left:12px;line-height:22px;}
 dt{clear:left;float:left;width:33%;font-weight:bold;}
 dd{margin-bottom:12px;font-size:11px;white-space:nowrap;}
 dd p{margin:0 0 4px 0;}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -14,7 +14,7 @@ a.info:hover span.left{left:-182px;}
 a.nohand{cursor:default;}
 i.spacing{margin-left:-6px;margin-right:-4px;}
 hr{border:none;margin:12px 0;}
-input[type=text],input[type=password],input[type=number],input[type=url],input[type=email],textarea,.textarea{font-family:arimo;font-size:11px;color:#303030;background-color:#FFFFFF;border:1px solid #E0E0E0;padding:2px 6px;min-height:20px;line-height:20px;outline:none;width:305px;margin:0 10px 0 0;box-shadow:inset 1px 1px 5px #F0F0F0;}
+input[type=text],input[type=password],input[type=number],input[type=url],input[type=email],textarea,.textarea{font-family:arimo;font-size:11px;color:#303030;background-color:#FFFFFF;border:1px solid #E0E0E0;border-radius:4px;padding:2px 6px;min-height:20px;line-height:20px;outline:none;width:305px;margin:0 10px 0 0;box-shadow:inset 1px 1px 5px #F0F0F0;}
 input[type=submit],input[type=reset],input[type=button],button[type=button],a.button{font-family:arimo;font-size:11px;position:relative;display:inline-block;padding:5px 10px;border:1px solid #E8E8E8;border-radius:5px;margin:7px 14px 0 0;text-decoration:none;white-space:nowrap;cursor:pointer;outline:none;color:#303030;background:-webkit-radial-gradient(#F0F0F0,#C8C8C8);background:linear-gradient(#F0F0F0,#C8C8C8);}
 input[type=checkbox]{vertical-align:middle;margin-right:6px;}
 input[type=number]::-webkit-outer-spin-button,input[type=number]::-webkit-inner-spin-button{-webkit-appearance: none;}

--- a/plugins/dynamix/styles/dynamix-black.css
+++ b/plugins/dynamix/styles/dynamix-black.css
@@ -19,15 +19,15 @@ div.jGrowl div.jGrowl-notify div.jGrowl-header{font-weight:bold;font-size:.9em;}
 div.jGrowl div.jGrowl-notify div.jGrowl-close{z-index:999;float:right;font-weight:bold;font-size:12px;cursor:pointer;}
 div.jGrowl div.jGrowl-closer{padding:4px 0;cursor:pointer;font-size:11px;font-weight:bold;text-align:center;}
 @media print{div.jGrowl{display:none;}}
-.ui-dropdownchecklist{background:-webkit-radial-gradient(#505050,#303030);background:linear-gradient(#505050,#303030);border-radius:4px;cursor:pointer;}
+.ui-dropdownchecklist{background:-webkit-radial-gradient(#505050,#303030);background:linear-gradient(#505050,#303030);border:none;box-shadow:0 2px 0 #404040;border-radius:4px;outline:none;cursor:pointer;height:22px;line-height:22px;}
 .ui-dropdownchecklist-group{font-weight:normal;font-style:italic;padding:1px 9px 1px 8px;}
-.ui-dropdownchecklist-selector{height:22px;border:1px solid #404040;display:inline-block;cursor:pointer;padding:1px 9px 1px 8px;}
+.ui-dropdownchecklist-selector{border:1px solid #404040;display:inline-block;cursor:pointer;padding:1px 9px 1px 8px;}
 .ui-dropdownchecklist-selector-wrapper{vertical-align:middle;font-size:0;}
 .ui-state-active{background:linear-gradient(#303030,#101010);background:-webkit-radial-gradient(#303030,#101010);}
 .ui-dropdownchecklist-dropcontainer{background:#000000;border:1px solid #404040;}
 .ui-state-disabled{background:linear-gradient(#202020,#101010);background:-webkit-radial-gradient(#202020,#101010);}
 .ui-dropdownchecklist-indent{padding-left:7px;}
-.ui-dropdownchecklist-text{color:#A0A0A0;line-height:22px;font-size:11px;}
+.ui-dropdownchecklist-text{color:#A0A0A0;font-size:11px;}
 .ui-dropdownchecklist-item{}
 #sb-title-inner,#sb-info-inner,#sb-loading-inner,div.sb-message{font-family:arimo,arial,sans-serif;color:#333333;}
 #sb-container{position:fixed;margin:0;padding:0;top:0;left:0;z-index:999;text-align:left;visibility:hidden;display:none;}

--- a/plugins/dynamix/styles/dynamix-white.css
+++ b/plugins/dynamix/styles/dynamix-white.css
@@ -19,15 +19,15 @@ div.jGrowl div.jGrowl-notify div.jGrowl-header{font-weight:bold;font-size:.9em;}
 div.jGrowl div.jGrowl-notify div.jGrowl-close{z-index:999;float:right;font-weight:bold;font-size:12px;cursor:pointer;}
 div.jGrowl div.jGrowl-closer{padding:4px 0;cursor:pointer;font-size:11px;font-weight:bold;text-align:center;}
 @media print{div.jGrowl{display:none;}}
-.ui-dropdownchecklist{background:-webkit-radial-gradient(#F4F4F4,#FCFCFC);background:linear-gradient(#F4F4F4,#FCFCFC);border-radius:4px;cursor:pointer;}
+.ui-dropdownchecklist{background:-webkit-radial-gradient(#F4F4F4,#FCFCFC);background:linear-gradient(#F4F4F4,#FCFCFC);border:none;box-shadow:0 2px 0 #E0E0E0,inset 0 -1px #FFFFFF;border-radius:4px;outline:none;cursor:pointer;height:22px;line-height:22px;}
 .ui-dropdownchecklist-group{font-weight:normal;font-style:italic;padding:1px 9px 1px 8px;}
-.ui-dropdownchecklist-selector{height:22px;border:1px solid #E0E0E0;display:inline-block;cursor:pointer;padding:1px 9px 1px 8px;}
+.ui-dropdownchecklist-selector{border:1px solid #E0E0E0;display:inline-block;cursor:pointer;padding:1px 9px 1px 8px;}
 .ui-dropdownchecklist-selector-wrapper{vertical-align:middle;font-size:0;}
 .ui-state-active{background:linear-gradient(#E8E8E8,#F8F8F8);background:-webkit-radial-gradient(#E8E8E8,#F8F8F8);}
 .ui-dropdownchecklist-dropcontainer{background:#FFFFFF;border:1px solid #E0E0E0;}
 .ui-state-disabled{background:linear-gradient(#F0F0F0,#F8F8F8);background:-webkit-radial-gradient(#F0F0F0,#F8F8F8);}
 .ui-dropdownchecklist-indent{padding-left:7px;}
-.ui-dropdownchecklist-text{color:#303030;line-height:22px;font-size:11px;}
+.ui-dropdownchecklist-text{color:#303030;font-size:11px;}
 .ui-dropdownchecklist-item{}
 #sb-title-inner,#sb-info-inner,#sb-loading-inner,div.sb-message{font-family:arimo,arial,sans-serif;color:#333333;}
 #sb-container{position:fixed;margin:0;padding:0;top:0;left:0;z-index:999;text-align:left;visibility:hidden;display:none;}


### PR DESCRIPTION
Sometimes Markdown inserts an unecessary "&lt;p&gt;&lt;/p&gt;" combination, causing the table header to be shifted for which a corrective workaround was included.

Inserted now an empty line at the top of the .page file which prevents Markdown from doing this in the first place and not needing to do the corrective workaround afterwards.
