### PR TITLE
bug fixes to vm manager

### DIFF
--- a/plugins/dynamix.vm.manager/VMSettings.page
+++ b/plugins/dynamix.vm.manager/VMSettings.page
@@ -46,7 +46,7 @@ foreach ($arrSyslinuxCfg as &$strSyslinuxCfg) {
 }
 
 if ($boolACSEnabled != $boolACSInSyslinux) {
-	?><p class="notice">You must reboot in to <b><?=$strCurrentLabel?></b> mode for changes to take effect</p><?php
+	?><p class="notice">You must reboot for changes to take effect</p><?php
 }
 ?>
 <link type="text/css" rel="stylesheet" href="/plugins/dynamix.vm.manager/styles/dynamix.vm.manager.css">

--- a/plugins/dynamix.vm.manager/VMSettings.page
+++ b/plugins/dynamix.vm.manager/VMSettings.page
@@ -22,6 +22,15 @@ if ($libvirt_filecheck) {
 }
 
 
+// Check for Intel VT-x (vmx) or AMD-V (svm) cpu virtualzation support
+$strCPUInfo = file_get_contents('/proc/cpuinfo');
+
+if (strpos($strCPUInfo, 'vmx') === false && strpos($strCPUInfo, 'svm') === false) {
+	?><p class="notice">Your hardware does not have Intel VT-x or AMD-V capability.  This is required to create VMs in KVM. <a href="http://lime-technology.com/wiki/index.php/UnRAID_Manual_6#Hardware-Assisted_Virtualization_.28HVM.29" target="_blank">Click here to see the unRAID Wiki for more information</a></p><?php
+	exit;
+}
+
+
 // Check for PCIE ACS capabilities
 $boolACSEnabled = (strpos(file_get_contents('/proc/cmdline'), 'pcie_acs_override=') !== false);
 

--- a/plugins/dynamix.vm.manager/classes/libvirt.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt.php
@@ -115,14 +115,13 @@
 					</clock>";
 
 			$hyperv = '';
-			if (!empty($domain['os']) && $domain['os'] == "windows") {
-				if ($domain['hyperv']){
-					$hyperv = "<hyperv>
-								<relaxed state='on'/>
-								<vapic state='on'/>
-								<spinlocks state='on' retries='8191'/>
-							</hyperv>";
-				}
+			if (!empty($domain['os']) && $domain['os'] == "windows" && $domain['hyperv']) {
+				$hyperv = "<hyperv>
+							<relaxed state='on'/>
+							<vapic state='on'/>
+							<spinlocks state='on' retries='8191'/>
+						</hyperv>";
+
 				$clock = "<clock offset='" . $domain['clock'] . "'>
 							<timer name='hypervclock' present='yes'/>
 							<timer name='hpet' present='no'/>

--- a/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
@@ -11,7 +11,7 @@
 	// Create domain config if needed
 	$domain_cfgfile = "/boot/config/domain.cfg";
 	if (!file_exists($domain_cfgfile)) {
-		file_put_contents($domain_cfgfile, 'ENABLED="no"'."\n".'DEBUG="no"'."\n".'MEDIADIR="/mnt/"'."\n".'DISKDIR="/mnt/"'."\n");
+		file_put_contents($domain_cfgfile, 'SERVICE="disable"'."\n".'DEBUG="no"'."\n".'MEDIADIR="/mnt/"'."\n".'DISKDIR="/mnt/"'."\n".'BRNAME=""'."\n");
 	} else {
 		// This will clean any ^M characters (\r) caused by windows from the config file
 		shell_exec("sed -i 's!\r!!g' '$domain_cfgfile'");
@@ -26,7 +26,7 @@
 
 	$domain_bridge = (!($domain_cfg['BRNAME'])) ? $var['BRNAME'] : $domain_cfg['BRNAME'];
 	$msg = (empty($domain_bridge)) ? "Error: Setup Bridge in Settings/Network Settings" : false;
-	$libvirt_service = isset($domain_cfg['SERVICE']) ?	$domain_cfg['SERVICE'] : "enable";
+	$libvirt_service = isset($domain_cfg['SERVICE']) ?	$domain_cfg['SERVICE'] : "disable";
 
 	if ($libvirt_running == "yes"){
 		$uri = is_dir('/proc/xen') ? 'xen:///system' : 'qemu:///system';

--- a/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
@@ -295,10 +295,10 @@
 			'domain' => [
 				'name' => $lv->domain_get_name($res),
 				'desc' => $lv->domain_get_description($res),
-				'persistent' => 1, //TODO?
+				'persistent' => 1,
 				'uuid' => $lv->domain_get_uuid($res),
 				'clock' => $lv->domain_get_clock_offset($res),
-				'os' => 'windows', //TODO?
+				'os' => ($lv->domain_get_clock_offset($res) == 'localtime' ? 'windows' : 'other'),
 				'arch' => $lv->domain_get_arch($res),
 				'machine' => (strpos($lv->domain_get_machine($res), 'i440fx') !== false ? 'pc' : 'q35'),
 				'mem' => $lv->domain_get_current_memory($res),

--- a/plugins/dynamix.vm.manager/event/disks_mounted
+++ b/plugins/dynamix.vm.manager/event/disks_mounted
@@ -16,6 +16,6 @@ if [ "$SERVICE" = "enable" ]; then
 	# Start libvirt
 	if [ -x /etc/rc.d/rc.libvirt ]; then
 	  logger "Starting libvirt"
-	  /etc/rc.d/rc.libvirt start | logger
+	  /etc/rc.d/rc.libvirt start |& logger
 	fi
 fi

--- a/plugins/dynamix.vm.manager/event/unmounting_disks
+++ b/plugins/dynamix.vm.manager/event/unmounting_disks
@@ -3,7 +3,7 @@
 # Shutdown libvirt
 if [ -x /etc/rc.d/rc.libvirt ]; then
   logger "Stopping libvirt"
-  /etc/rc.d/rc.libvirt stop | logger
+  /etc/rc.d/rc.libvirt stop |& logger
 fi
 
 if [ "$(mount | grep domain.img)" ]; then


### PR DESCRIPTION
- suppress console errors upon starting libvirt
- fix default values in the seed domain.cfg file created in /boot/config/