### PR TITLE
Add custom agents to Notifications

### DIFF
--- a/plugins/dynamix.docker.manager/dockerClient.php
+++ b/plugins/dynamix.docker.manager/dockerClient.php
@@ -583,7 +583,7 @@ class DockerClient {
 
 			$c["Image"]       = $obj['Image'];
 			$c["ImageId"]     = substr($details[0]["Image"],0,12);
-			$c["Name"]        = substr($obj['Names'][0], 1);
+			$c["Name"]        = substr($details[0]['Name'], 1);
 			$c["Status"]      = $status;
 			$c["Running"]     = $running;
 			$c["Cmd"]         = $obj['Command'];

--- a/plugins/dynamix/Notifications.page
+++ b/plugins/dynamix/Notifications.page
@@ -52,12 +52,12 @@ function resetNotify(form) {
 function prepareNotify(form) {
   var events = [];
   form.entity.value = form.normal1.checked | form.warning1.checked | form.alert1.checked;
-  form.normal.value = form.normal1.checked*1 + form.normal2.checked*2;
-  form.warning.value = form.warning1.checked*1 + form.warning2.checked*2;
-  form.alert.value = form.alert1.checked*1 + form.alert2.checked*2;
-  form.plugin.value = form.plugin1.checked*1 + form.plugin2.checked*2;
-  form.docker_notify.value = form.docker_notify1.checked*1 + form.docker_notify2.checked*2;
-  form.report.value = form.report1.checked*1 + form.report2.checked*2;
+  form.normal.value = form.normal1.checked*1 + form.normal2.checked*2 + form.normal3.checked*4;
+  form.warning.value = form.warning1.checked*1 + form.warning2.checked*2 + form.warning3.checked*4;
+  form.alert.value = form.alert1.checked*1 + form.alert2.checked*2 + form.alert3.checked*4;
+  form.plugin.value = form.plugin1.checked*1 + form.plugin2.checked*2 + form.plugin3.checked*4;
+  form.docker_notify.value = form.docker_notify1.checked*1 + form.docker_notify2.checked*2 + form.docker_notify3.checked*4;
+  form.report.value = form.report1.checked*1 + form.report2.checked*2 + form.report3.checked*4;
   form.normal1.disabled = true;
   form.normal2.disabled = true;
   form.warning1.disabled = true;
@@ -192,30 +192,43 @@ Array status notification:
 
 > Start a periodic array health check (preventive maintenance) and notify the user the result of this check.
 > Use the checkboxes below to select how notifications need to be given, browser, email or both.
+> <br><b>Tip:</b> you can use custom notification agents; just add them to "/boot/config/plugins/dynamix/notification/agents" directory and check 'Custom'.
 
 <span class="plugin" style="display:none">&nbsp;</span>
-: <span class="plugin" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Plugins version</span><input type="checkbox" name="plugin1"<?=($notify['plugin'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
-  <input type="checkbox" name="plugin2"<?=($notify['plugin'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;</span>
+: <span class="plugin" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Plugins version</span>
+  <input type="checkbox" name="plugin1"<?=($notify['plugin'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
+  <input type="checkbox" name="plugin2"<?=($notify['plugin'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;
+  <input type="checkbox" name="plugin3"<?=($notify['plugin'] & 4)==4 ? ' checked' : ''?>>Custom &nbsp;</span>
 
 <span class="docker" style="display:none">&nbsp;</span>
-: <span class="docker" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Docker update</span><input type="checkbox" name="docker_notify1"<?=($notify['docker_notify'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
-  <input type="checkbox" name="docker_notify2"<?=($notify['docker_notify'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;</span>
+: <span class="docker" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Docker update</span>
+  <input type="checkbox" name="docker_notify1"<?=($notify['docker_notify'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
+  <input type="checkbox" name="docker_notify2"<?=($notify['docker_notify'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;
+  <input type="checkbox" name="docker_notify3"<?=($notify['docker_notify'] & 4)==4 ? ' checked' : ''?>>Custom &nbsp;</span>
 
 <span class="report" style="display:none">&nbsp;</span>
-: <span class="report" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Array status</span><input type="checkbox" name="report1"<?=($notify['report'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
-  <input type="checkbox" name="report2"<?=($notify['report'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;</span>
+: <span class="report" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Array status</span>
+  <input type="checkbox" name="report1"<?=($notify['report'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
+  <input type="checkbox" name="report2"<?=($notify['report'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;
+  <input type="checkbox" name="report3"<?=($notify['report'] & 4)==4 ? ' checked' : ''?>>Custom &nbsp;</span>
 
 Notification entity:
-: <span style="display:inline-block;width:90px;font-style:italic">Notices</span><input type="checkbox" class="checkbox" name="normal1"<?=($notify['normal'] & 1)==1 ? " checked $disabled" : $disabled?>>Browser &nbsp;
+: <span style="display:inline-block;width:90px;font-style:italic">Notices</span>
+  <input type="checkbox" class="checkbox" name="normal1"<?=($notify['normal'] & 1)==1 ? " checked $disabled" : $disabled?>>Browser &nbsp;
   <input type="checkbox" class="checkbox" name="normal2"<?=($notify['normal'] & 2)==2 ? " checked $disabled" : $disabled?>>Email &nbsp;
+  <input type="checkbox" class="checkbox" name="normal3"<?=($notify['normal'] & 4)==4 ? " checked $disabled" : $disabled?>>Custom &nbsp;
 
 &nbsp;
-: <span style="display:inline-block;width:90px;font-style:italic">Warnings</span><input type="checkbox" class="checkbox" name="warning1"<?=($notify['warning'] & 1)==1 ? " checked $disabled" : $disabled?>>Browser &nbsp;
+: <span style="display:inline-block;width:90px;font-style:italic">Warnings</span>
+  <input type="checkbox" class="checkbox" name="warning1"<?=($notify['warning'] & 1)==1 ? " checked $disabled" : $disabled?>>Browser &nbsp;
   <input type="checkbox" class="checkbox" name="warning2"<?=($notify['warning'] & 2)==2 ? " checked $disabled" : $disabled?>>Email &nbsp;
+  <input type="checkbox" class="checkbox" name="warning3"<?=($notify['warning'] & 4)==4 ? " checked $disabled" : $disabled?>>Custom &nbsp;
 
 &nbsp;
-: <span style="display:inline-block;width:90px;font-style:italic">Alerts</span><input type="checkbox" class="checkbox" name="alert1"<?=($notify['alert'] & 1)==1 ? " checked $disabled" : $disabled?>>Browser &nbsp;
+: <span style="display:inline-block;width:90px;font-style:italic">Alerts</span>
+  <input type="checkbox" class="checkbox" name="alert1"<?=($notify['alert'] & 1)==1 ? " checked $disabled" : $disabled?>>Browser &nbsp;
   <input type="checkbox" class="checkbox" name="alert2"<?=($notify['alert'] & 2)==2 ? " checked $disabled" : $disabled?>>Email &nbsp;
+  <input type="checkbox" class="checkbox" name="alert3"<?=($notify['alert'] & 4)==4 ? " checked $disabled" : $disabled?>>Custom &nbsp;
 
 > Notifications are classified as:
 >

--- a/plugins/dynamix/Notifications.page
+++ b/plugins/dynamix/Notifications.page
@@ -191,9 +191,8 @@ Array status notification:
   </select>
 
 > Start a periodic array health check (preventive maintenance) and notify the user the result of this check.
-> Use the checkboxes below to select how notifications need to be given, browser, email or both.
-> <br><b>Tip:</b> you can use custom notification agents; just add them to "/boot/config/plugins/dynamix/notification/agents" directory and check 'Custom'.
 
+Available Notifications:
 <span class="plugin" style="display:none">&nbsp;</span>
 : <span class="plugin" style="display:none"><span style="display:inline-block;width:90px;font-style:italic">Plugins version</span>
   <input type="checkbox" name="plugin1"<?=($notify['plugin'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
@@ -211,6 +210,10 @@ Array status notification:
   <input type="checkbox" name="report1"<?=($notify['report'] & 1)==1 ? ' checked' : ''?>>Browser &nbsp;
   <input type="checkbox" name="report2"<?=($notify['report'] & 2)==2 ? ' checked' : ''?>>Email &nbsp;
   <input type="checkbox" name="report3"<?=($notify['report'] & 4)==4 ? ' checked' : ''?>>Custom &nbsp;</span>
+
+> Use the checkboxes above to select what and how notifications need to be given, browser, email or both.
+> <br><b>Tip:</b> you can use custom notification agents; just add them to "/boot/config/plugins/dynamix/notification/agents" directory and check 'Custom'.
+
 
 Notification entity:
 : <span style="display:inline-block;width:90px;font-style:italic">Notices</span>

--- a/plugins/dynamix/scripts/notify
+++ b/plugins/dynamix/scripts/notify
@@ -179,10 +179,11 @@ case 'add':
   $archive = "{$archive}/{$event}-{$ticket}.notify";
   if (file_exists($archive)) break;
   $entity = $overrule===false ? $notify[$importance] : $overrule;
+
   if (!$mailtest) file_put_contents($archive,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
-  if (($entity & 1)==1 && !$mailtest) {file_put_contents($unread,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n")};
-  if (($entity & 2)==2 || $mailtest) { if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message)) exit(1); }
-  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents) && count($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT='$event' SUBJECT='$subject' DESCRIPTION='$description' IMPORTANCE='$importance' ".$agent); }}};
+  if (($entity & 1)==1 && !$mailtest) file_put_contents($unread,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
+  if (($entity & 2)==2 || $mailtest)  if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message)) exit(1);
+  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT='$event' SUBJECT='$subject' DESCRIPTION='$description' IMPORTANCE='$importance' ".$agent);};}};
   break;
 
 case 'get':

--- a/plugins/dynamix/scripts/notify
+++ b/plugins/dynamix/scripts/notify
@@ -86,6 +86,15 @@ if ($argc == 1) exit(usage());
 extract(parse_plugin_cfg("dynamix",true));
 $unread  = "{$notify['path']}/unread";
 $archive = "{$notify['path']}/archive";
+$plugins_dir = "/boot/config/plugins/dynamix/notifications/plugins";
+if (is_dir($plugins_dir)) {
+  $plugins = array();
+  foreach (array_diff(scandir($plugins_dir), array('.','..')) as $p) {
+    if (is_executable("${plugins_dir}/${p}")) $plugins[] = "${plugins_dir}/${p}";
+  }
+} else {
+  $plugins = NULL;
+}
 
 switch ($argv[1][0]=='-' ? 'add' : $argv[1]) {
 case 'init':
@@ -171,7 +180,10 @@ case 'add':
   if (file_exists($archive)) break;
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   if (!$mailtest) file_put_contents($archive,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
-  if (($entity & 1)==1 && !$mailtest) file_put_contents($unread,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
+  if (($entity & 1)==1 && !$mailtest) {
+    file_put_contents($unread,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
+    if (is_array($plugins) && count($plugins)) foreach ($plugins as $plugin) exec("TIMESTAMP='$timestamp' EVENT='$event' SUBJECT='$subject' DESCRIPTION='$description' IMPORTANCE='$importance' ".$plugin);
+  }
   if (($entity & 2)==2 || $mailtest) { if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message)) exit(1); }
   break;
 

--- a/plugins/dynamix/scripts/notify
+++ b/plugins/dynamix/scripts/notify
@@ -86,14 +86,14 @@ if ($argc == 1) exit(usage());
 extract(parse_plugin_cfg("dynamix",true));
 $unread  = "{$notify['path']}/unread";
 $archive = "{$notify['path']}/archive";
-$plugins_dir = "/boot/config/plugins/dynamix/notifications/plugins";
-if (is_dir($plugins_dir)) {
-  $plugins = array();
-  foreach (array_diff(scandir($plugins_dir), array('.','..')) as $p) {
-    if (is_executable("${plugins_dir}/${p}")) $plugins[] = "${plugins_dir}/${p}";
+$agents_dir = "/boot/config/plugins/dynamix/notifications/agents";
+if (is_dir($agents_dir)) {
+  $agents = array();
+  foreach (array_diff(scandir($agents_dir), array('.','..')) as $p) {
+    if (is_executable("${agents_dir}/${p}")) $agents[] = "${agents_dir}/${p}";
   }
 } else {
-  $plugins = NULL;
+  $agents = NULL;
 }
 
 switch ($argv[1][0]=='-' ? 'add' : $argv[1]) {
@@ -180,11 +180,9 @@ case 'add':
   if (file_exists($archive)) break;
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   if (!$mailtest) file_put_contents($archive,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
-  if (($entity & 1)==1 && !$mailtest) {
-    file_put_contents($unread,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n");
-    if (is_array($plugins) && count($plugins)) foreach ($plugins as $plugin) exec("TIMESTAMP='$timestamp' EVENT='$event' SUBJECT='$subject' DESCRIPTION='$description' IMPORTANCE='$importance' ".$plugin);
-  }
+  if (($entity & 1)==1 && !$mailtest) {file_put_contents($unread,"timestamp = $timestamp\nevent = $event\nsubject = $subject\ndescription = $description\nimportance = $importance\n")};
   if (($entity & 2)==2 || $mailtest) { if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message)) exit(1); }
+  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents) && count($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT='$event' SUBJECT='$subject' DESCRIPTION='$description' IMPORTANCE='$importance' ".$agent); }}};
   break;
 
 case 'get':


### PR DESCRIPTION
Please disregard the info on last commit:

This allow users add custom agents to notifications, like Pushbullet or
Twitter. I hardcoded the agents directory to "/boot/config/plugins/dynamix/notifications/agents" because it doesn’t make
sense put them on the temp dir.

This is an example of a Pushbullet “plugin”:
#!/bin/bash
AUTH=""
DATE=$(date --date="@$TIMESTAMP" '+%Y/%m/%d %H:%M:%S')

curl -s -k -L --header "Authorization: Bearer $AUTH" \
-X POST https://api.pushbullet.com/v2/pushes --header
'Content-Type: application/json' \
-d "{\"type\": \"note\", \"title\": \"$DATE - $EVENT\", \"body\":
\"$DESCRIPTION\"}"