### PR TITLE
VM Manager: Fix: prevent console logging domain.img change ownership …

### DIFF
--- a/plugins/dynamix.vm.manager/classes/libvirt.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt.php
@@ -171,7 +171,7 @@
 
 					// create folder if needed
 					if (!is_dir($strImgFolder)) {
-						mkdir($strImgFolder);
+						mkdir($strImgFolder, 0777, true);
 					}
 
 					$this->set_folder_nodatacow($strImgFolder);
@@ -185,7 +185,7 @@
 
 					// create parent folder if needed
 					if (!is_dir($path_parts['dirname'])) {
-						mkdir($path_parts['dirname']);
+						mkdir($path_parts['dirname'], 0777, true);
 					}
 
 					$this->set_folder_nodatacow($path_parts['dirname']);

--- a/plugins/dynamix.vm.manager/classes/libvirt.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt.php
@@ -75,7 +75,7 @@
 				$folder = str_replace('/mnt/user', '/mnt/' . $tmp['user.LOCATION'], $folder);  // replace 'user' with say 'cache' or 'disk1' etc
 			}
 
-			@shell_exec("chattr +C -R " . escapeshellarg($folder) . " >/dev/null");
+			@shell_exec("chattr +C -R " . escapeshellarg($folder) . " &>/dev/null");
 
 			return true;
 		}

--- a/plugins/dynamix.vm.manager/event/started
+++ b/plugins/dynamix.vm.manager/event/started
@@ -22,7 +22,7 @@ if grep -q 'fsState="Started"' /var/local/emhttp/var.ini && grep -q 'startMode="
 	#copy seed loopback image and qemu hook, if needed, to flash drive
 	if [ -d /usr/local/emhttp/plugins/dynamix.vm.manager/dynamix.kvm.manager ]; then
 		mkdir -p /boot/config/plugins/dynamix.kvm.manager
-		tar -xkf /usr/local/emhttp/plugins/dynamix.vm.manager/dynamix.kvm.manager/domain.tar.xz -C /boot/config/plugins/dynamix.kvm.manager/
+		tar --no-same-owner -xkf /usr/local/emhttp/plugins/dynamix.vm.manager/dynamix.kvm.manager/domain.tar.xz -C /boot/config/plugins/dynamix.kvm.manager/
 		cp -n /usr/local/emhttp/plugins/dynamix.vm.manager/dynamix.kvm.manager/qemu /boot/config/plugins/dynamix.kvm.manager/
 	fi
 


### PR DESCRIPTION
VM Manager: Fix: prevent console logging domain.img change ownership errors upon first time starting array.

Tar attempts to change the ownership on the libvirt loopback seed file extracted to /boot/config/plugins/dynamix.kvm.manager/domain.img but vfat doesn't support uid:gid unix ownership attributes.  