### PR TITLE
User List: make icons 48x48 and look for custom user icon on flash drive

### DIFF
--- a/plugins/dynamix/UserList.page
+++ b/plugins/dynamix/UserList.page
@@ -2,8 +2,8 @@ Menu="Users"
 Title="Users"
 ---
 <?PHP
-/* Copyright 2014, Lime Technology
- * Copyright 2014, Bergware International.
+/* Copyright 2015, Lime Technology
+ * Copyright 2015, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,
@@ -15,7 +15,7 @@ Title="Users"
 ?>
 
 <?foreach ($users as $user):?>
-  <div class="user-list"><center><a href="<?=$path?>/UserEdit?name=<?=$user['name'];?>"><img src="/webGui/images/user.png" border="0"><br><?=$user['name']?></a><br><span style="font-size: 10px"><?=$user['desc']?></span></center></div>
+  <div class="user-list"><center><a class="<?=(!empty($user['desc']) ? 'info' : '')?>" href="<?=$path?>/UserEdit?name=<?=$user['name'];?>"><img src="<?=(is_file($img='/boot/config/plugins/dynamix/users/'.$user['name'].'.png') ? $img : '/webGui/images/user.png')?>" border="0" width="48" height="48"><br><?=$user['name']?><span><?=$user['desc']?></span></a></center></div>
 <?endforeach;?>
 <div style='clear:both'></div>
 <form method="GET" action="<?=$path?>/UserAdd">


### PR DESCRIPTION
Referencing #163 - User list modifications:
- Show all user icons as 48x48
- Use custom user icon if found under /boot/config/plugins/dynamix/users/<username>.png
- Description is only shown on mouse hover