### PR TITLE
VM Manager file permissions and more Diagnostics

### DIFF
--- a/plugins/dynamix.vm.manager/classes/libvirt.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt.php
@@ -468,6 +468,11 @@
 							$arrUsedBootOrders[] = 1;
 						}
 
+						$readonly = '';
+						if (!empty($disk['readonly'])) {
+							$readonly = '<readonly/>';
+						}
+
 						$strDevType = @filetype(realpath($disk['image']));
 
 						if ($strDevType == 'file' || $strDevType == 'block') {
@@ -478,6 +483,7 @@
 											<source " . $strSourceType . "='" . htmlspecialchars($disk['image'], ENT_QUOTES | ENT_XML1) . "'/>
 											<target bus='" . $disk['bus'] . "' dev='" . $disk['dev'] . "'/>
 											$bootorder
+											$readonly
 										</disk>";
 						}
 					}

--- a/plugins/dynamix.vm.manager/classes/libvirt.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt.php
@@ -172,6 +172,8 @@
 					// create folder if needed
 					if (!is_dir($strImgFolder)) {
 						mkdir($strImgFolder, 0777, true);
+						chown($strImgFolder, 'nobody');
+						chgrp($strImgFolder, 'users');
 					}
 
 					$this->set_folder_nodatacow($strImgFolder);
@@ -186,6 +188,8 @@
 					// create parent folder if needed
 					if (!is_dir($path_parts['dirname'])) {
 						mkdir($path_parts['dirname'], 0777, true);
+						chown($path_parts['dirname'], 'nobody');
+						chgrp($path_parts['dirname'], 'users');
 					}
 
 					$this->set_folder_nodatacow($path_parts['dirname']);
@@ -200,6 +204,9 @@
 					$return_value = 0;
 				} else {
 					$strLastLine = exec("qemu-img create -q -f " . escapeshellarg($disk['driver']) . " " . escapeshellarg($strImgPath) . " " . escapeshellarg($disk['size']), $output, $return_value);
+					chmod($strImgPath, 0777);
+					chown($strImgPath, 'nobody');
+					chgrp($strImgPath, 'users');
 				}
 
 				if ($return_value != 0) {

--- a/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
@@ -323,6 +323,19 @@
 	}
 
 
+	function getLatestMachineType($strType = 'i440fx') {
+		$arrMachineTypes = getValidMachineTypes();
+
+		foreach ($arrMachineTypes as $key => $value) {
+			if (stripos($key, $strType) !== false) {
+				return $key;
+			}
+		}
+
+		return array_shift(array_keys($arrMachineTypes));
+	}
+
+
 	function getValidDiskDrivers() {
 		$arrValidDiskDrivers = [
 			'raw' => 'raw',

--- a/plugins/dynamix/scripts/diagnostics
+++ b/plugins/dynamix/scripts/diagnostics
@@ -34,6 +34,8 @@ foreach ($ports as $port) {
   file_put_contents("/$diag/system/ethtool.txt", "--------------------------------\r\n", FILE_APPEND);
 }
 exec("ifconfig|todos >/$diag/system/ifconfig.txt");
+exec("find /sys/kernel/iommu_groups/ -type l|todos >/$diag/system/iommu_groups.txt");
+exec("cat /proc/cmdline >/$diag/system/cmdline.txt");
 exec("cp /boot/config/*.{cfg,conf,dat} /boot/config/go /$diag/config 2>/dev/null");
 if (is_dir("/boot/config/shares")) exec("cp /boot/config/shares/*.cfg /$diag/shares 2>/dev/null");
 $ini = "/var/local/emhttp/shares.ini";


### PR DESCRIPTION
**VM Manager**
- Created files and folders are now set to nobody:users with 0777 permissions
- Allow readonly disks and helper function for getting latest machine emulation type (needed for OpenELEC)

**Diagnositcs**
- new file: /system/cmdline.txt  -- shows currently active kernel boot parameters (`cat /proc/cmdline`)
- new file: /system/iommu_groups.txt -- dump of all iommu groups (`find /sys/kernel/iommu_groups/ -type l`)