### PR TITLE
Force browser no-cache when default stylesheets or dynamix.js changes

### DIFF
--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -22,8 +22,8 @@
 <link type="text/css" rel="stylesheet" href="/webGui/styles/default-fonts.css">
 <link type="text/css" rel="stylesheet" href="/webGui/styles/font-awesome.css">
 <link type="text/css" rel="stylesheet" href="/webGui/styles/jquery.sweetalert.css">
-<link type="text/css" rel="stylesheet" href="/webGui/styles/default-<?=$display['theme']?>.css">
-<link type="text/css" rel="stylesheet" href="/webGui/styles/dynamix-<?=$display['theme']?>.css">
+<link type="text/css" rel="stylesheet" href="/webGui/styles/default-<?=$display['theme']?>.css?<?=$_VERSION?>">
+<link type="text/css" rel="stylesheet" href="/webGui/styles/dynamix-<?=$display['theme']?>.css?<?=$_VERSION?>">
 <?if (file_exists("/boot/config/plugins/dynamix/banner.png")):?>
 <link type="text/css" rel="stylesheet" href="/webGui/styles/custom-banner.css">
 <?else:?>
@@ -34,7 +34,7 @@
 .inline_help{display:none;}
 </style>
 
-<script src="/webGui/javascript/dynamix.js"></script>
+<script src="/webGui/javascript/dynamix.js?<?=$_VERSION?>"></script>
 <script>
 Shadowbox.init({skipSetup:true});
 

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -22,8 +22,8 @@
 <link type="text/css" rel="stylesheet" href="/webGui/styles/default-fonts.css">
 <link type="text/css" rel="stylesheet" href="/webGui/styles/font-awesome.css">
 <link type="text/css" rel="stylesheet" href="/webGui/styles/jquery.sweetalert.css">
-<link type="text/css" rel="stylesheet" href="/webGui/styles/default-<?=$display['theme']?>.css?<?=$_VERSION?>">
-<link type="text/css" rel="stylesheet" href="/webGui/styles/dynamix-<?=$display['theme']?>.css?<?=$_VERSION?>">
+<link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-{$display['theme']}.css")?>">
+<link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/dynamix-{$display['theme']}.css")?>">
 <?if (file_exists("/boot/config/plugins/dynamix/banner.png")):?>
 <link type="text/css" rel="stylesheet" href="/webGui/styles/custom-banner.css">
 <?else:?>
@@ -34,7 +34,7 @@
 .inline_help{display:none;}
 </style>
 
-<script src="/webGui/javascript/dynamix.js?<?=$_VERSION?>"></script>
+<script src="<?autov("/webGui/javascript/dynamix.js")?>"></script>
 <script>
 Shadowbox.init({skipSetup:true});
 

--- a/plugins/dynamix/include/Helpers.php
+++ b/plugins/dynamix/include/Helpers.php
@@ -198,4 +198,8 @@ function input_private_users($sec) {
 function is_block($path) {
   return (@filetype(realpath($path)) == 'block');
 }
+function autov($file) {
+  global $docroot;
+  echo "$file?v=".filemtime($docroot.$file);
+}
 ?>

--- a/plugins/dynamix/include/Helpers.php
+++ b/plugins/dynamix/include/Helpers.php
@@ -200,6 +200,7 @@ function is_block($path) {
 }
 function autov($file) {
   global $docroot;
+  clearstatcache(true, $docroot.$file);
   echo "$file?v=".filemtime($docroot.$file);
 }
 ?>

--- a/plugins/dynamix/template.php
+++ b/plugins/dynamix/template.php
@@ -50,5 +50,6 @@ $myPage = $site[basename($path)];
 $pageroot = "{$docroot}/".dirname($myPage['file']);
 
 // Giddyup
+$_VERSION = 'v=1'; // increment when default stylesheets or dynamix.js changes 
 require_once('include/DefaultPageLayout.php');
 ?>

--- a/plugins/dynamix/template.php
+++ b/plugins/dynamix/template.php
@@ -50,6 +50,5 @@ $myPage = $site[basename($path)];
 $pageroot = "{$docroot}/".dirname($myPage['file']);
 
 // Giddyup
-$_VERSION = 'v=1'; // increment when default stylesheets or dynamix.js changes 
 require_once('include/DefaultPageLayout.php');
 ?>


### PR DESCRIPTION
When the 'version' postfix changes, it will force the browser to load a
no-cache version of the file.