### PR TITLE
Force show lsof port numbers to get emhttp port

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugincheck
+++ b/plugins/dynamix.plugin.manager/scripts/plugincheck
@@ -15,7 +15,7 @@
 require_once '/usr/local/emhttp/webGui/include/Wrappers.php';
 require_once '/usr/local/emhttp/plugins/dynamix.plugin.manager/include/PluginHelpers.php';
 
-exec("wget -qO /dev/null 127.0.0.1:$(lsof -iTCP -sTCP:LISTEN|grep -Pom1 '^emhttp.*:\K\d+')/update.htm?cmdStatus=apply");
+exec("wget -qO /dev/null 127.0.0.1:$(lsof -i -P -sTCP:LISTEN|grep -Pom1 '^emhttp.*:\K\d+')/update.htm?cmdStatus=apply");
 
 $current = parse_ini_file('/etc/unraid-version');
 $var     = parse_ini_file('/var/local/emhttp/var.ini');

--- a/plugins/dynamix/scripts/monitor
+++ b/plugins/dynamix/scripts/monitor
@@ -12,7 +12,7 @@
  */
 ?>
 <?
-exec("wget -qO /dev/null 127.0.0.1:$(lsof -iTCP -sTCP:LISTEN|grep -Pom1 '^emhttp.*:\K\d+')/update.htm?cmdStatus=apply");
+exec("wget -qO /dev/null 127.0.0.1:$(lsof -i -P -sTCP:LISTEN|grep -Pom1 '^emhttp.*:\K\d+')/update.htm?cmdStatus=apply");
 
 $disks = parse_ini_file("/var/local/emhttp/disks.ini",true);
 $var   = parse_ini_file("/var/local/emhttp/var.ini");

--- a/plugins/dynamix/scripts/statuscheck
+++ b/plugins/dynamix/scripts/statuscheck
@@ -13,7 +13,7 @@
 ?>
 <?
 require_once '/usr/local/emhttp/webGui/include/Wrappers.php';
-exec("wget -qO /dev/null 127.0.0.1:$(lsof -iTCP -sTCP:LISTEN|grep -Pom1 '^emhttp.*:\K\d+')/update.htm?cmdStatus=apply");
+exec("wget -qO /dev/null 127.0.0.1:$(lsof -i -P -sTCP:LISTEN|grep -Pom1 '^emhttp.*:\K\d+')/update.htm?cmdStatus=apply");
 
 $notify = "/usr/local/emhttp/webGui/scripts/notify";
 $disks  = parse_ini_file("/var/local/emhttp/disks.ini",true);


### PR DESCRIPTION
Without the `-P` argument `lsof` will output port names (e.g. 'http') instead of '80' and the regex used in the grep fails to parse anything useful.